### PR TITLE
Fix Python 3 SyntaxError for octal literals

### DIFF
--- a/oauth2.py
+++ b/oauth2.py
@@ -185,9 +185,9 @@ def cache_refresh_token():
     # If the path doesn't already exist, create it, otherwise
     # just ensure it is private
     if not os.path.exists(TOKEN_CACHE_PATH):
-        os.mkdir(TOKEN_CACHE_PATH, 0700)
+        os.mkdir(TOKEN_CACHE_PATH, 0o700)
     else:
-        os.chmod(TOKEN_CACHE_PATH, 0700)
+        os.chmod(TOKEN_CACHE_PATH, 0o700)
 
     cache_file = os.path.join(TOKEN_CACHE_PATH, "refresh")
     with open(cache_file, "w") as cfile:


### PR DESCRIPTION
I've been seeing the following when running the plain ``owa_checker`` command within my daily "start up" set up script:

```python
Traceback (most recent call last):
  File "/project/ukmo/rhel7/apps/lib/owa_checker/owa_checker.py", line 27, in <module>
    import oauth2
  File "/net/project/ukmo/rhel7/apps/lib/owa_checker/oauth2.py", line 188
    os.mkdir(TOKEN_CACHE_PATH, 0700)
                                  ^
SyntaxError: invalid token
```

The simple cause is that Python 3 does not recognise digits with leading zeroes as any numeric type (as picked up also by the Python syntax highlighting). In Python 2, a single leading zero is recognised as an octal number, as I assume is what is desired here in context, but this was changed for 3, as described [under PEP 3127](https://www.python.org/dev/peps/pep-3127/#removal-of-old-octal-syntax). Using the ``0o<digits>`` syntax [ensures](https://stackoverflow.com/questions/50345204/how-to-write-an-octal-value-in-python-2-3) this code works in both Python 2 & 3.

Since it's a very easy fix, I thought I would put in a PR.