### PR TITLE
Update README instructions for new Azure portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,13 @@ Before you can use OWA Checker you need to create a new application profile
 for it within Microsoft's Azure system.  The steps here may vary depending on
 your site but will be something like:
 
- 1. Navigate to apps.dev.microsoft.com and sign in using your account (which
+ 1. Navigate to portal.azure.com and sign in using your account (which
     should redirect to your own site's infrastructure)
  2. The app name doesn't matter, call it something like "OWA Checker"
  3. Under Authentication use "Web" and Redirect URI of "http://localhost:1234"
  4. In the Overview, make a note of the "Application (client) ID"
- 5. Under Certificates, make a note of the "Clent Secret" (create one if needed)
+ 5. Under Certificates, make a note of the "Client Secret" (create one if
+    needed)
  6. Under API Permissions, ensure that the app has the following:
      * Calendars.Read
      * Mail.Read


### PR DESCRIPTION
The README.md instructions state under the Under 'Microsoft Azure Setup' section to "navigate to apps.dev.microsoft.com and sign in". Doing so, I see a deprecation warning for that site ("portal"):

*"Application registrations portal has been deprecated for registering and managing converged applications since May 2019 and this functionality will be removed starting September 2019. Go to the App registrations (now Generally Available) experience in the Azure portal."*

The (root URL for the) newer app that refers to is, as linked to in a button after that message, is **portal.azure.com**.

So the referenced deprecated link can be updated to the above to bypass the redirection stage.

[Also, there is a typo I spotted in the README which I have corrected here.]